### PR TITLE
updated the expected result for test_create_spend_chart

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -90,7 +90,7 @@ class UnitTests(unittest.TestCase):
         self.entertainment.withdraw(33.40)
         self.business.withdraw(10.99)
         actual = create_spend_chart([self.business, self.food, self.entertainment])
-        expected = "Percentage spent by category\n100|          \n 90|          \n 80|          \n 70|    o     \n 60|    o     \n 50|    o     \n 40|    o     \n 30|    o     \n 20|    o  o  \n 10|    o  o  \n  0| o  o  o  \n    ----------\n     B  F  E  \n     u  o  n  \n     s  o  t  \n     i  d  e  \n     n     r  \n     e     t  \n     s     a  \n     s     i  \n           n  \n           m  \n           e  \n           n  \n           t  "
+        expected = "Percentage spent by category\n100|          \n 90|          \n 80|          \n 70|          \n 60|          \n 50|          \n 40|          \n 30|          \n 20|          \n 10|    o     \n  0| o  o  o  \n    ----------\n     B  F  E  \n     u  o  n  \n     s  o  t  \n     i  d  e  \n     n     r  \n     e     t  \n     s     a  \n     s     i  \n           n  \n           m  \n           e  \n           n  \n           t  "
         self.assertEqual(actual, expected, 'Expected different chart representation. Check that all spacing is exact.')
 
 if __name__ == "__main__":


### PR DESCRIPTION
I can't see how the expected result for  test_create_spend_chart is correct. Given for example that the entertainment category is listed as having >= 10* spend - in the test case there's a deposit for 900 then a withdrawal of 10.99, so that would be 1.2% - or perhaps the deposits weren't all meant to be 900?