### PR TITLE
Correct data to match the chart

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -86,7 +86,7 @@ class UnitTests(unittest.TestCase):
         self.food.deposit(900, "deposit")
         self.entertainment.deposit(900, "deposit")
         self.business.deposit(900, "deposit")
-        self.food.withdraw(105.55)
+        self.food.withdraw(705.55)
         self.entertainment.withdraw(33.40)
         self.business.withdraw(10.99)
         actual = create_spend_chart([self.business, self.food, self.entertainment])


### PR DESCRIPTION
If withdraw only 105.55 then only take 105.55/900 ~ 11.73%
If withdraw were 705.55 then it is about 78.39% then matched the chart

Otherwise have to change chart data (column Food)