### PR TITLE
fix: Correct `test_create_spend_chart` test expected output

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -97,7 +97,7 @@ class UnitTests(unittest.TestCase):
         self.entertainment.withdraw(33.40)
         self.business.withdraw(10.99)
         actual = create_spend_chart([self.business, self.food, self.entertainment])
-        expected = "Percentage spent by category\n100|          \n 90|          \n 80|          \n 70|    o     \n 60|    o     \n 50|    o     \n 40|    o     \n 30|    o     \n 20|    o  o  \n 10|    o  o  \n  0| o  o  o  \n    ----------\n     B  F  E  \n     u  o  n  \n     s  o  t  \n     i  d  e  \n     n     r  \n     e     t  \n     s     a  \n     s     i  \n           n  \n           m  \n           e  \n           n  \n           t  "
+        expected = "Percentage spent by category\n100|          \n 90|          \n 80|          \n 70|    o     \n 60|    o     \n 50|    o     \n 40|    o     \n 30|    o     \n 20|    o  o  \n 10| o  o  o  \n  0| o  o  o  \n    ----------\n     B  F  E  \n     u  o  n  \n     s  o  t  \n     i  d  e  \n     n     r  \n     e     t  \n     s     a  \n     s     i  \n           n  \n           m  \n           e  \n           n  \n           t  "
         self.assertEqual(actual, expected, 'Expected different chart representation. Check that all spacing is exact.')
 
 if __name__ == "__main__":


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Corrected the `test_create_spend_chart` test to correctly show `10.99` as `10%` in the chart for the category `Business`. The calculation I followed to get to this was:

> Sum of category withdrawals = Total expedeniture
> ---
> *Total expedeniture*
> 10.99 (business) + 105.55 (food) + 33.40 (entertainment) = 149.94

Each percentege to be shown in the chart is then calculated by:

> (Category withdrawal / Total expenditure) * 100 = Percentage spent in category
> ---
> *Business*
> (10.99 / 149.94) * 100 = 7.33 % (2 decimal places)
> 
> *Food*
> (105.55 / 149.94) * 100 = 70.39 % (2 decimal places)
> 
> *Entertainment*
> (33.40 / 149.94) * 100 = 22.28 % (2 decimal places)

Each of these then rounded to the nearest 10 produces:

> *Business*
> 10%
> 
> *Food*
> 70%
> 
> *Entertainment*
> 20%

This also neatly adds to 100%, but the current test expects Business to be only filled to the 0% value in the y-axis.
Happy to discuss this if I've misinterpreted and/or made a mistake here!